### PR TITLE
Update BombExplodesHelper.cs to save new tile heights

### DIFF
--- a/BombExplodesHelper.cs
+++ b/BombExplodesHelper.cs
@@ -23,6 +23,8 @@ namespace BombsAway
 
                 bombModeActive.AfterEffects(xPos, yPos, newX, newY, tileObjectId);
             }
+            
+            WorldManager.manageWorld.heightChunkHasChanged(newX, newY);
         }
 
         internal static IEnumerator StartExplosion(BombExplodes instance, int xPos, int yPos, int initialHeight)


### PR DESCRIPTION
Added heightChunkHasChanged so new tile heights get saved.

Tiles with changed heights were not being saved.  After exit/reload, they would revert, unless something else triggered that chunk to save it's tile heights.  Telling worldManager that tile heights have changed for each affected tile causes them to save correctly.